### PR TITLE
Fix pam misconfiguration for SUSE systems

### DIFF
--- a/service/realmd-suse.conf
+++ b/service/realmd-suse.conf
@@ -27,10 +27,9 @@ winbind-disable-service = /usr/bin/systemctl disable winbind.service
 winbind-restart-service = /usr/bin/systemctl restart winbind.service
 winbind-stop-service = /usr/bin/systemctl stop winbind.service
 
-# TODO: pam-config doesn't have support for --sssd
 # TODO: How do we enable sssd in /etc/nsswitch.conf?
-sssd-enable-logins = /usr/sbin/pam-config --add --sssd --mkhomedir
-sssd-disable-logins = /usr/sbin/pam-config --delete --sssd
+sssd-enable-logins = /usr/sbin/pam-config --add --sss --mkhomedir
+sssd-disable-logins = /usr/sbin/pam-config --delete --sss
 sssd-enable-service = /usr/bin/systemctl enable sssd.service
 sssd-disable-service = /usr/bin/systemctl disable sssd.service
 sssd-restart-service = /usr/bin/systemctl restart sssd.service


### PR DESCRIPTION
The right option is `--sss` instead of `--sssd`

See for reference:

https://github.com/SUSE/pam-config/blob/e8921a6c4722536399f4bbd6cf6ee6ff571cae0f/src/pam-config.8.xml#L1309


